### PR TITLE
adding required css for expandable tables

### DIFF
--- a/styles/scss/molecules/table.scss
+++ b/styles/scss/molecules/table.scss
@@ -106,7 +106,7 @@
     }
 }
 
-.gds-table__row {
+.gds-table__row:not(.gds-table--expandable-row) {
     background-color: rgba($gg-light-4, 0);
     @include transition-ease-out(all, 250ms);
 
@@ -261,14 +261,14 @@
 
 // Striped table
 .gds-table--striped {
-    tr:nth-of-type(even) {
+    tr:nth-child(even of :not(.gds-table--expandable-row)) {
         background-color: rgba($gg-light-4, 0.1);
         &:hover {
             background-color: rgba($gg-light-4, 0.2);
         }
     }
     .gds-table__row--selected,
-    .gds-table__row--selected:nth-of-type(even) {
+    .gds-table__row--selected:nth-child(even of :not(.gds-table--expandable-row)) {
         background-color: rgba($tableRowPrimaryColor, 0.65);
         color: white;
         &:hover {
@@ -285,15 +285,15 @@
 // Inverse striped table
 .gds-table--inverse-striped {
     tr:hover,
-    tr:nth-of-type(even):hover {
+    tr:nth-child(even of :not(.gds-table--expandable-row)):hover {
         background-color: $gg-dark-3;
     }
 
-    tr:nth-of-type(even) {
+    tr:nth-child(even of :not(.gds-table--expandable-row)) {
         background-color: mix($gg-dark-2, white, 96%);
     }
     .gds-table__row--inverse-selected,
-    .gds-table__row--inverse-selected:nth-of-type(even) {
+    .gds-table__row--inverse-selected:nth-of-type(even of :not(.gds-table--expandable-row)) {
         background-color: rgba($gg-dark-4, 1);
         color: white;
         &:hover {
@@ -301,7 +301,6 @@
         }
     }
 }
-
 .gds-table__row--inverse-selected {
     background-color: rgba($gg-dark-4, 1);
     color: white;
@@ -408,5 +407,31 @@
     opacity: 0;
     > .gds-table__row {
         display: none;
+    }
+}
+
+.gds-table--expandable tbody tr {
+    &.gds-table--expandable-row {
+        td {
+            border-bottom: 0;
+            padding: 0;
+            .gds-table--collapsible {
+                overflow: hidden;
+                transition: cubic-bezier(0.165, 0.84, 0.44, 1);
+                transition-property: opacity;
+                transition-duration: 1s;
+                opacity: 1;
+                > div {
+                    padding: 1.5rem;
+                    border-bottom: 1px solid $grayLight2Color;
+                }
+            }
+        }
+    }
+    &:not(:has(.expanded)) + tr.gds-table--expandable-row {
+        td .gds-table--collapsible {
+            opacity: 0;
+            transition-duration: 0.25s;
+        }
     }
 }


### PR DESCRIPTION
These styles were adjusted to handle the expandable rows for gumdrops using the renderExpandableColumn method.

The striped styles were adjusted as there's an additional row inserted after each row when a renderExpandableColumn is placed on a column object.

This allows the striped styles to continue to work by ignoring the expandable rows.

gumdrops pr: https://github.com/gumgum/gumdrops/pull/114

I didn't update the docs for the new classes that were added as individually they won't work to expand anything, there's logic from gumdrops that performs the expanding functionality